### PR TITLE
商品情報編集機能(furima)

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -23,6 +23,20 @@ before_action :authenticate_user!, only: [:new, :create]
     @item = Item.find(params[:id])
   end
   
+  def edit
+    @item = Item.find(params[:id])
+  end
+
+  def update
+      item = Item.find(params[:id])
+      
+    if item.update(item_params)
+      redirect_to item_path(item)
+    else
+      render :edit
+    end
+  end
+
   #def sold_out?購入管理機能時の実装で使用
     #!!self.order
   #end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,13 +1,18 @@
 class ItemsController < ApplicationController
-before_action :authenticate_user!, only: [:new, :create]
+  before_action :authenticate_user!, only: [:new, :create, :edit, :update]
+  before_action :set_item, only: [:show, :edit, :update]
+  before_action :move_to_index, only: [:edit, :update]
+
 
   def index
     @items = Item.includes(:user).order("created_at DESC")
   end
 
+
   def new
     @item = Item.new
   end
+
 
   def create
     @item = Item.new(item_params)
@@ -19,21 +24,18 @@ before_action :authenticate_user!, only: [:new, :create]
     end
   end
   
+
   def show
-    @item = Item.find(params[:id])
   end
   
-  def edit
-    @item = Item.find(params[:id])
+  def edit   
   end
 
-  def update
-      item = Item.find(params[:id])
-      
-    if item.update(item_params)
-      redirect_to item_path(item)
+  def update         # @item = Item.find(params[:id])の部分は「set_itemメソッドに移行」
+    if @item.update(item_params)
+      redirect_to item_path(@item)
     else
-      render :edit
+      render :edit, status: :unprocessable_entity
     end
   end
 
@@ -43,9 +45,15 @@ before_action :authenticate_user!, only: [:new, :create]
 
 private
 
-  def item_params
+    def set_item
+      @item = Item.find(params[:id])
+    end
+
+    def move_to_index
+      redirect_to action: :index unless current_user.id == @item.user_id
+    end
+
+    def item_params
     params.require(:item).permit(:image,:item_name,:item_info,:category_id,:condition_id,:shipping_cost_id,:prefecture_id,:shipping_day_id,:price).merge(user_id: current_user.id)
+    end
   end
-
-
-end

--- a/app/views/items/edit.html.erb
+++ b/app/views/items/edit.html.erb
@@ -9,10 +9,8 @@ app/assets/stylesheets/items/new.css %>
     <h2 class="items-sell-title">商品の情報を入力</h2>
     <%= form_with model: @item, local: true do |f| %>
     
-    <%# インスタンスを渡して、エラー発生時にメッセージが表示されるようにしましょう。%>
     <%= render 'shared/error_messages', model: f.object %>
-    <%# //インスタンスを渡して、エラー発生時にメッセージが表示されるようにしましょう。%>
-    
+
     <%# 商品画像 %>
     <div class="img-upload">
       <div class="weight-bold-text">

--- a/app/views/items/edit.html.erb
+++ b/app/views/items/edit.html.erb
@@ -7,12 +7,12 @@ app/assets/stylesheets/items/new.css %>
   </header>
   <div class="items-sell-main">
     <h2 class="items-sell-title">商品の情報を入力</h2>
-    <%= form_with local: true do |f| %>
-
+    <%= form_with model: @item, local: true do |f| %>
+    
     <%# インスタンスを渡して、エラー発生時にメッセージが表示されるようにしましょう。%>
-    <%# render 'shared/error_messages', model: f.object %>
+    <%= render 'shared/error_messages', model: f.object %>
     <%# //インスタンスを渡して、エラー発生時にメッセージが表示されるようにしましょう。%>
-
+    
     <%# 商品画像 %>
     <div class="img-upload">
       <div class="weight-bold-text">
@@ -23,7 +23,7 @@ app/assets/stylesheets/items/new.css %>
         <p>
           クリックしてファイルをアップロード
         </p>
-        <%= f.file_field :hoge, id:"item-image" %>
+        <%= f.file_field :image, id:"item-image" %>
       </div>
     </div>
     <%# /商品画像 %>
@@ -33,13 +33,13 @@ app/assets/stylesheets/items/new.css %>
         商品名
         <span class="indispensable">必須</span>
       </div>
-      <%= f.text_area :hoge, class:"items-text", id:"item-name", placeholder:"商品名（必須 40文字まで)", maxlength:"40" %>
+      <%= f.text_area :item_name, class:"items-text", id:"item-name", placeholder:"商品名（必須 40文字まで)", maxlength:"40" %>
       <div class="items-explain">
         <div class="weight-bold-text">
           商品の説明
           <span class="indispensable">必須</span>
         </div>
-        <%= f.text_area :hoge, class:"items-text", id:"item-info", placeholder:"商品の説明（必須 1,000文字まで）（色、素材、重さ、定価、注意点など）例）2010年頃に1万円で購入したジャケットです。ライトグレーで傷はありません。あわせやすいのでおすすめです。" ,rows:"7" ,maxlength:"1000" %>
+        <%= f.text_area :item_info, class:"items-text", id:"item-info", placeholder:"商品の説明（必須 1,000文字まで）（色、素材、重さ、定価、注意点など）例）2010年頃に1万円で購入したジャケットです。ライトグレーで傷はありません。あわせやすいのでおすすめです。" ,rows:"7" ,maxlength:"1000" %>
       </div>
     </div>
     <%# /商品名と商品説明 %>
@@ -52,12 +52,12 @@ app/assets/stylesheets/items/new.css %>
           カテゴリー
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-category"}) %>
+        <%= f.collection_select(:category_id, Category.all, :id, :name, {}, {class:"select-box", id:"item-category"}) %>
         <div class="weight-bold-text">
           商品の状態
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-sales-status"}) %>
+        <%= f.collection_select(:condition_id, Condition.all, :id, :name, {}, {class:"select-box", id:"item-sales-status"}) %>
       </div>
     </div>
     <%# /商品の詳細 %>
@@ -73,17 +73,17 @@ app/assets/stylesheets/items/new.css %>
           配送料の負担
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-shipping-fee-status"}) %>
+        <%= f.collection_select(:shipping_cost_id, ShippingCost.all, :id, :name, {}, {class:"select-box", id:"item-shipping-fee-status"}) %>
         <div class="weight-bold-text">
           発送元の地域
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-prefecture"}) %>
+        <%= f.collection_select(:prefecture_id,Prefecture.all, :id, :name, {}, {class:"select-box", id:"item-prefecture"}) %>
         <div class="weight-bold-text">
           発送までの日数
           <span class="indispensable">必須</span>
         </div>
-        <%= f.collection_select(:hoge, [], :hoge, :hoge, {}, {class:"select-box", id:"item-scheduled-delivery"}) %>
+        <%= f.collection_select(:shipping_day_id,ShippingDay.all, :id, :name, {}, {class:"select-box", id:"item-scheduled-delivery"}) %>
       </div>
     </div>
     <%# /配送について %>
@@ -101,7 +101,7 @@ app/assets/stylesheets/items/new.css %>
             <span class="indispensable">必須</span>
           </div>
           <span class="sell-yen">¥</span>
-          <%= f.text_field :hoge, class:"price-input", id:"item-price", placeholder:"例）300" %>
+          <%= f.text_field :price, class:"price-input", id:"item-price", placeholder:"例）300" %>
         </div>
         <div class="price-content">
           <span>販売手数料 (10%)</span>
@@ -141,7 +141,7 @@ app/assets/stylesheets/items/new.css %>
     <%# 下部ボタン %>
     <div class="sell-btn-contents">
       <%= f.submit "変更する" ,class:"sell-btn" %>
-      <%=link_to 'もどる', "#", class:"back-btn" %>
+      <%=link_to 'もどる', item_path, class:"back-btn" %>
     </div>
     <%# /下部ボタン %>
   </div>

--- a/app/views/items/show.html.erb
+++ b/app/views/items/show.html.erb
@@ -28,8 +28,8 @@
     
     <% if user_signed_in? %>
     <% if current_user.id == @item.user_id %>
-    
-      <%= link_to "商品の編集", "#", method: :get, class: "item-red-btn" %>
+      
+      <%= link_to "商品の編集", edit_item_path(@item), method: :get, class: "item-red-btn" %>
     <p class="or-text">or</p>
       <%= link_to "削除", "#", data: {turbo_method: :delete}, class:"item-destroy" %>
 

--- a/app/views/shared/_error_messages.html.erb
+++ b/app/views/shared/_error_messages.html.erb
@@ -1,7 +1,7 @@
-<% if @item.errors.any? %>
+<% if model.errors.any? %>
 <div class="error-alert">
   <ul>
-    <% @item.errors.full_messages.each do |message| %>
+    <% model.errors.full_messages.each do |message| %>
     <li class='error-message'><%= message %></li>
     <% end %>
   </ul>

--- a/app/views/shared/_error_messages.html.erb
+++ b/app/views/shared/_error_messages.html.erb
@@ -1,9 +1,10 @@
-<% if model.errors.any? %>
+<% if @item.errors.any? %>
 <div class="error-alert">
   <ul>
-    <% model.errors.full_messages.each do |message| %>
+    <% @item.errors.full_messages.each do |message| %>
     <li class='error-message'><%= message %></li>
     <% end %>
   </ul>
 </div>
 <% end %>
+

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,6 +5,6 @@ Rails.application.routes.draw do
   root to: 'items#index'
   
   
-  resources :items, only: [:index, :new, :create,:show]
+  resources :items, only: [:index, :new, :create, :show, :edit, :update]
 
 end


### PR DESCRIPTION
＃ What（何を）　
フリマアプリの実装

＃ Why（なぜ）
課題遂行のため


ログイン状態の出品者は、商品情報編集ページに遷移できる動画
https://gyazo.com/27cc150a98e82bda7ba3cfedffd2a778

 必要な情報を適切に入力して「更新する」ボタンを押すと、商品の情報を編集できる動画
https://gyazo.com/01fbe69adea793b96c1c552f4b3a23a5

 入力に問題がある状態で「変更する」ボタンが押された場合、情報は保存されず、編集ページに戻りエラーメッセージが表示される動画
https://gyazo.com/f2bb569299ec9cb4e534afc2b7c19c71

 何も編集せずに「更新する」ボタンを押しても、画像無しの商品にならない動画
https://gyazo.com/ac159bea32857c3f267c4d1e0b4fdef0

 ログイン状態の場合でも、URLを直接入力して自身が出品していない商品の商品情報編集ページへ遷移しようとすると、商品の販売状況に関わらずトップページに遷移する動画
https://gyazo.com/4addf7bf2686b1d244d457e1c96cf826

 ログイン状態の場合でも、URLを直接入力して自身が出品した売却済み商品の商品情報編集ページへ遷移しようとすると、トップページに遷移する動画（現段階で商品購入機能の実装が済んでいる場合）
https://gyazo.com/e8e49358e1d8127a63cd4313dd4654fd

 ログアウト状態の場合は、URLを直接入力して商品情報編集ページへ遷移しようとすると、商品の販売状況に関わらずログインページに遷移する動画
https://gyazo.com/4a8d111022eaa1c98f4d1a59dcf8ed65

 商品名やカテゴリーの情報など、すでに登録されている商品情報は商品情報編集画面を開いた時点で表示される動画（商品画像・販売手数料・販売利益に関しては、表示されない状態で良い）
https://gyazo.com/4c649a6a56c66c28015d2996a5bb60cb
